### PR TITLE
Introduce project scaffolding with allocator prototype

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,11 @@
+# Open Issues
+
+## 1. Integrate gzip compression
+Assigned to: Jeremy
+
+Implement `erm_compress.c` using zlib to compress buffers on close and decompress on open.
+
+## 2. Sarcastic code review
+Assigned to: Tuesday
+
+Provide sarcastic feedback on the current architecture and potential improvements.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+CC?=gcc
+CFLAGS?=-Wall -Wextra -O2 -g -Iinclude
+
+SRCS=src/erm_alloc.c src/ermfs.c
+OBJS=$(SRCS:.c=.o)
+LIB=libermfs.a
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $^
+
+clean:
+	rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
 
 > **Early Incantation** — actively architecting. Codex is the team lead. Tuesday is judging silently. Jeremy is a UNIX wizard.
 
+## Build
+
+Run `make` to build the static library `libermfs.a`.
+
 ## License
 
 🧙‍♂️ Sorcerer's License, v1.0 — Use at your own peril. May summon tempfiles.

--- a/include/ermfs/erm_alloc.h
+++ b/include/ermfs/erm_alloc.h
@@ -1,0 +1,23 @@
+#ifndef ERM_ALLOC_H
+#define ERM_ALLOC_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Allocate an anonymous memory region of given size. Returns pointer on success or NULL. */
+void *erm_alloc(size_t initial_size);
+
+/* Resize a previously allocated memory region. May return a new pointer. */
+void *erm_resize(void *ptr, size_t old_size, size_t new_size);
+
+/* Free a memory region allocated with erm_alloc. */
+void erm_free(void *ptr, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ERM_ALLOC_H */

--- a/include/ermfs/ermfs.h
+++ b/include/ermfs/ermfs.h
@@ -1,0 +1,34 @@
+#ifndef ERMFS_H
+#define ERMFS_H
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct erm_file;
+
+typedef struct erm_file erm_file;
+
+/* Create a new in-memory file with specified initial capacity. */
+erm_file *ermfs_create(size_t initial_size);
+
+/* Write data to the file, growing as needed. Returns bytes written or -1. */
+ssize_t ermfs_write(erm_file *file, const void *data, size_t len);
+
+/* Obtain a pointer to the internal buffer. */
+void *ermfs_data(erm_file *file);
+
+/* Current size of the file. */
+size_t ermfs_size(erm_file *file);
+
+/* Close and free the file. */
+void ermfs_close(erm_file *file);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ERMFS_H */

--- a/src/erm_alloc.c
+++ b/src/erm_alloc.c
@@ -1,0 +1,37 @@
+#define _GNU_SOURCE
+#include "ermfs/erm_alloc.h"
+
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+void *erm_alloc(size_t initial_size) {
+    if (initial_size == 0) {
+        initial_size = getpagesize();
+    }
+    void *ptr = mmap(NULL, initial_size, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (ptr == MAP_FAILED) {
+        return NULL;
+    }
+    return ptr;
+}
+
+void *erm_resize(void *ptr, size_t old_size, size_t new_size) {
+    if (!ptr) {
+        return erm_alloc(new_size);
+    }
+    void *new_ptr = mremap(ptr, old_size, new_size, MREMAP_MAYMOVE);
+    if (new_ptr == MAP_FAILED) {
+        return NULL;
+    }
+    return new_ptr;
+}
+
+void erm_free(void *ptr, size_t size) {
+    if (!ptr || size == 0) {
+        return;
+    }
+    munmap(ptr, size);
+}

--- a/src/ermfs.c
+++ b/src/ermfs.c
@@ -1,0 +1,64 @@
+#include "ermfs/ermfs.h"
+#include "ermfs/erm_alloc.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+struct erm_file {
+    void *data;
+    size_t size;
+    size_t capacity;
+};
+
+erm_file *ermfs_create(size_t initial_size) {
+    erm_file *file = malloc(sizeof(*file));
+    if (!file) {
+        return NULL;
+    }
+    file->data = erm_alloc(initial_size);
+    if (!file->data) {
+        free(file);
+        return NULL;
+    }
+    file->size = 0;
+    file->capacity = initial_size;
+    return file;
+}
+
+ssize_t ermfs_write(erm_file *file, const void *data, size_t len) {
+    if (!file || !data) {
+        return -1;
+    }
+    size_t required = file->size + len;
+    if (required > file->capacity) {
+        size_t newcap = file->capacity * 2;
+        if (newcap < required) {
+            newcap = required;
+        }
+        void *newdata = erm_resize(file->data, file->capacity, newcap);
+        if (!newdata) {
+            return -1;
+        }
+        file->data = newdata;
+        file->capacity = newcap;
+    }
+    memcpy((char *)file->data + file->size, data, len);
+    file->size += len;
+    return (ssize_t)len;
+}
+
+void *ermfs_data(erm_file *file) {
+    return file ? file->data : NULL;
+}
+
+size_t ermfs_size(erm_file *file) {
+    return file ? file->size : 0;
+}
+
+void ermfs_close(erm_file *file) {
+    if (!file) {
+        return;
+    }
+    erm_free(file->data, file->capacity);
+    free(file);
+}


### PR DESCRIPTION
## Summary
- add Makefile to build `libermfs`
- implement basic in-place allocator
- prototype minimal file API using the allocator
- provide build instructions in README
- track open tasks in `ISSUES.md`

## Testing
- `make`
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6848aea562e08327b9e1d04d015672eb