### PR TITLE
Implement ERMFD memfd export layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC?=gcc
 CFLAGS?=-Wall -Wextra -O2 -g -Iinclude
 LDFLAGS?=-lz -lpthread
 
-SRCS=src/erm_alloc.c src/ermfs.c src/erm_compress.c
+SRCS=src/erm_alloc.c src/ermfs.c src/erm_compress.c src/ermfd.c
 OBJS=$(SRCS:.c=.o)
 LIB=libermfs.a
 

--- a/include/ermfs/erm_internal.h
+++ b/include/ermfs/erm_internal.h
@@ -1,0 +1,33 @@
+#ifndef ERM_INTERNAL_H
+#define ERM_INTERNAL_H
+
+#include <pthread.h>
+#include <sys/types.h>
+#include <stddef.h>
+
+#include "ermfs.h"
+
+/* Internal ERMFS file structure */
+struct erm_file {
+    void *data;
+    size_t size;
+    size_t capacity;
+    int compressed;
+    size_t original_size;
+    off_t position;
+    int mode;
+    char *path;
+    int ref_count;
+    pthread_mutex_t mutex;
+};
+
+typedef struct erm_file erm_file;
+
+/* Lookup file by path in registry. Increments ref_count on success. */
+erm_file *ermfs_find_file_by_path(const char *path);
+
+/* Lock/unlock helpers for internal use */
+void ermfs_lock_file(erm_file *file);
+void ermfs_unlock_file(erm_file *file);
+
+#endif /* ERM_INTERNAL_H */

--- a/include/ermfs/ermfd.h
+++ b/include/ermfs/ermfd.h
@@ -1,0 +1,15 @@
+#ifndef ERMFD_H
+#define ERMFD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Export an ERMFS-managed file as a memfd-backed descriptor */
+int ermfs_export_memfd(const char *path, int flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ERMFD_H */

--- a/src/ermfd.c
+++ b/src/ermfd.c
@@ -1,0 +1,60 @@
+#define _GNU_SOURCE
+#include "ermfs/ermfd.h"
+#include "ermfs/erm_internal.h"
+#include "ermfs/ermfs.h"
+
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+int ermfs_export_memfd(const char *path, int flags) {
+    (void)flags;
+    if (!path) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    /* Lookup file object */
+    erm_file *file = ermfs_find_file_by_path(path);
+    if (!file) {
+        errno = ENOENT;
+        return -1;
+    }
+
+    int fd = memfd_create(path, MFD_CLOEXEC);
+    if (fd == -1) {
+        ermfs_destroy(file);
+        return -1;
+    }
+
+    /* Snapshot file contents while holding lock */
+    ermfs_lock_file(file);
+    void *data = ermfs_data(file);
+    size_t size = ermfs_size(file);
+    if (!data) {
+        ermfs_unlock_file(file);
+        close(fd);
+        ermfs_destroy(file);
+        errno = EIO;
+        return -1;
+    }
+
+    ssize_t off = 0;
+    while (off < (ssize_t)size) {
+        ssize_t written = write(fd, (char *)data + off, size - off);
+        if (written <= 0) {
+            ermfs_unlock_file(file);
+            close(fd);
+            ermfs_destroy(file);
+            return -1;
+        }
+        off += written;
+    }
+    lseek(fd, 0, SEEK_SET);
+    ermfs_unlock_file(file);
+    ermfs_destroy(file);
+
+    return fd;
+}

--- a/test_ermfd.c
+++ b/test_ermfd.c
@@ -1,0 +1,56 @@
+#include "ermfs/ermfs.h"
+#include "ermfs/ermfd.h"
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int main() {
+    printf("Testing ERMFD memfd export...\n");
+
+    const char *path = "/memfd/export.txt";
+    const char *msg = "Hello from memfd";
+
+    /* Create and write file */
+    ermfs_fd_t fd = ermfs_open(path, O_RDWR);
+    assert(fd >= 0);
+    assert(ermfs_write_fd(fd, msg, strlen(msg)) == (ssize_t)strlen(msg));
+
+    /* Export while file is still open */
+    int memfd = ermfs_export_memfd(path, 0);
+    assert(memfd >= 0);
+
+    /* Now close the original file */
+    assert(ermfs_close_fd(fd) == 0);
+
+    /* Read back */
+    char buf[64];
+    ssize_t r = read(memfd, buf, sizeof(buf) - 1);
+    assert(r == (ssize_t)strlen(msg));
+    buf[r] = '\0';
+    assert(strcmp(buf, msg) == 0);
+
+    /* mmap */
+    lseek(memfd, 0, SEEK_SET);
+    void *map = mmap(NULL, strlen(msg), PROT_READ, MAP_PRIVATE, memfd, 0);
+    assert(map != MAP_FAILED);
+    assert(memcmp(map, msg, strlen(msg)) == 0);
+    munmap(map, strlen(msg));
+
+    /* fstat */
+    struct stat st;
+    assert(fstat(memfd, &st) == 0);
+    assert(st.st_size == (off_t)strlen(msg));
+
+    close(memfd);
+
+    /* Error condition */
+    int bad = ermfs_export_memfd("/no/such/file", 0);
+    assert(bad == -1);
+
+    printf("ERMFD memfd export tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create `ermfd` module for exporting ERMFS files as memfd-backed descriptors
- expose internal structures and helpers in new `erm_internal.h`
- update core to provide registry lookup and locking helpers
- integrate new source into Makefile
- add unit tests exercising memfd export functionality

## Testing
- `gcc -Iinclude test_ermfd.c libermfs.a -lz -lpthread -o test_ermfd && ./test_ermfd >/tmp/test_ermfd.log && tail -n 5 /tmp/test_ermfd.log`

------
https://chatgpt.com/codex/tasks/task_e_6848d9567e888327899fc3f0d5f4c20f